### PR TITLE
FIX:  카테고리 / 글로벌 항목에 하위 항목 필드를 추가 함으로써 하위 항목에 대한 정보를 제공 한다. (#66)

### DIFF
--- a/src/assets/data/fields.ts
+++ b/src/assets/data/fields.ts
@@ -74,3 +74,5 @@ export const MOD_DATE = 'modDate';
 export const RECORD_NAME = 'recordName';
 export const LEVEL = 'level';
 export const TYPE = 'type';
+
+export const ITEM_COUNT = 'itemCount';

--- a/src/assets/data/fields.ts
+++ b/src/assets/data/fields.ts
@@ -76,3 +76,4 @@ export const LEVEL = 'level';
 export const TYPE = 'type';
 
 export const ITEM_COUNT = 'itemCount';
+export const SEMESTER_ITEM_COUNT = 'semesterItemCount';

--- a/src/pages/mileage/category/index.tsx
+++ b/src/pages/mileage/category/index.tsx
@@ -10,6 +10,7 @@ import {
   ORDER_IDX,
   TITLE,
   MOD_DATE,
+  ITEM_COUNT,
 } from 'src/assets/data/fields';
 import SWModal from 'src/components/common/modal/SWModal';
 import { EDITCATEGORY } from 'src/assets/data/modal/modals';
@@ -29,6 +30,7 @@ export enum MileageCategoryBoard {
   'ORDER_IDX' = ORDER_IDX,
   'DESCRIPTION1' = DESCRIPTION1,
   'DESCRIPTION2' = DESCRIPTION2,
+  'ITEM_COUNT' = ITEM_COUNT,
   'MOD_DATE' = MOD_DATE,
   'MANAGE' = MANAGE,
 }
@@ -45,6 +47,7 @@ interface Data {
   [MileageCategoryBoard.ORDER_IDX]: number;
   [MileageCategoryBoard.DESCRIPTION1]: string;
   [MileageCategoryBoard.DESCRIPTION2]: string;
+  [MileageCategoryBoard.ITEM_COUNT]: number;
   [MileageCategoryBoard.MOD_DATE]: string;
   [MileageCategoryBoard.MANAGE]: ReactNode;
 }
@@ -62,6 +65,7 @@ function createData(
   ORDER_IDX: number,
   DESCRIPTION1: string,
   DESCRIPTION2: string,
+  ITEM_COUNT: number,
   MOD_DATE: string,
   MANAGE: ReactNode
 ): Data {
@@ -72,6 +76,7 @@ function createData(
     [MileageCategoryBoard.ORDER_IDX]: ORDER_IDX,
     [MileageCategoryBoard.DESCRIPTION1]: DESCRIPTION1,
     [MileageCategoryBoard.DESCRIPTION2]: DESCRIPTION2,
+    [MileageCategoryBoard.ITEM_COUNT]: ITEM_COUNT,
     [MileageCategoryBoard.MOD_DATE]: MOD_DATE,
     [MileageCategoryBoard.MANAGE]: MANAGE,
   };
@@ -118,6 +123,12 @@ const headCells = [
     numeric: true,
     disablePadding: false,
     label: '설명2',
+  },
+  {
+    id: [MileageCategoryBoard.ITEM_COUNT],
+    numeric: true,
+    disablePadding: false,
+    label: '하위 항목 개수',
   },
   {
     id: [MileageCategoryBoard.MOD_DATE],
@@ -205,6 +216,7 @@ export default function MileageCategory({
       item[ORDER_IDX],
       item[DESCRIPTION1],
       item[DESCRIPTION2],
+      item[ITEM_COUNT],
       item[MOD_DATE],
       <SWModal type={EDITCATEGORY} beforeData={beforeData} />
     );

--- a/src/pages/mileage/item/global/index.tsx
+++ b/src/pages/mileage/item/global/index.tsx
@@ -44,7 +44,7 @@ export enum MileageGlobalItemBoard {
   'ITEM' = ITEM,
   'DESCRIPTION1' = DESCRIPTION1,
   'DESCRIPTION2' = DESCRIPTION2,
-
+  'SEMESTER_ITEM_COUNT' = SEMESTER_ITEM_COUNT,
   'ISVISIBLE' = ISVISIBLE,
   'MOD_DATE' = MOD_DATE,
   'MANAGE' = MANAGE,
@@ -59,7 +59,7 @@ interface Data {
   [MileageGlobalItemBoard.ITEM]: string;
   [MileageGlobalItemBoard.DESCRIPTION1]: string;
   [MileageGlobalItemBoard.DESCRIPTION2]: string;
-
+  [MileageGlobalItemBoard.SEMESTER_ITEM_COUNT]: number;
   [MileageGlobalItemBoard.ISVISIBLE]: boolean;
   [MileageGlobalItemBoard.MOD_DATE]: string;
   [MileageGlobalItemBoard.MANAGE]: string;
@@ -76,7 +76,7 @@ function createData(
   ITEM: string,
   DESCRIPTION1: string,
   DESCRIPTION2: string,
-
+  SEMESTER_ITEM_COUNT: number,
   ISVISIBLE: boolean,
   MOD_DATE: string,
   MANAGE: string
@@ -89,7 +89,7 @@ function createData(
 
     [MileageGlobalItemBoard.DESCRIPTION1]: DESCRIPTION1,
     [MileageGlobalItemBoard.DESCRIPTION2]: DESCRIPTION2,
-
+    [MileageGlobalItemBoard.SEMESTER_ITEM_COUNT]: SEMESTER_ITEM_COUNT,
     [MileageGlobalItemBoard.ISVISIBLE]: ISVISIBLE,
     [MileageGlobalItemBoard.MOD_DATE]: MOD_DATE,
     [MileageGlobalItemBoard.MANAGE]: MANAGE,
@@ -130,6 +130,12 @@ const headCells = [
     numeric: true,
     disablePadding: false,
     label: '설명2',
+  },
+  {
+    id: [MileageGlobalItemBoard.SEMESTER_ITEM_COUNT],
+    numeric: true,
+    disablePadding: false,
+    label: '학기별 항목 수',
   },
   {
     id: [MileageGlobalItemBoard.ISVISIBLE],
@@ -245,7 +251,7 @@ import axiosInstance from 'src/utils/axios';
 import { InferGetServerSidePropsType, GetServerSideProps } from 'next';
 import MileageCategory from 'src/components/board/MileageCategory';
 import { setItemList, setSemesterList } from 'src/redux/slices/filter';
-import { ID, CATEGORY, ITEM, ISVISIBLE } from '../../../../assets/data/fields';
+import { ID, CATEGORY, ITEM, ISVISIBLE, SEMESTER_ITEM_COUNT } from '../../../../assets/data/fields';
 
 interface ICategory {
   id: number;
@@ -317,6 +323,7 @@ export default function MileageCategory({
       item[NAME],
       item[DESCRIPTION1],
       item[DESCRIPTION2],
+      item[SEMESTER_ITEM_COUNT],
       item[ISVISIBLE],
       item[MOD_DATE],
       <SWModal type={EDITGLOBALITEM} beforeData={beforeData} />


### PR DESCRIPTION
## 요약

개선이 필요 했던 점 : 카테고리 / 글로벌 항목 삭제시 하위 항목이 존재할 시 validation 때문에 삭제가 되지 않는데 이를 삭제를 눌러야만 알 수 있다.

개선 한 점 : 카테고리 / 글로벌 항목 에 하위 항목의 갯수를 표시 해준다.

Backend PR : https://github.com/HGU-WALAB/sw-mileage-server-kt/pull/105

## 작업 사항

 카테고리에 하위 항목 갯수 표시
 마일리지 글로벌 항목이 사용된 학기별 마일리지 항목 개수 표시

## 이슈 번호 / 링크

#66 